### PR TITLE
Feat: add missing integrations

### DIFF
--- a/integration/api/defi-llama.mdx
+++ b/integration/api/defi-llama.mdx
@@ -1,0 +1,35 @@
+---
+title: "🦙 DefiLlama"
+description: "Open and transparent DeFi analytics"
+---
+
+[DefiLlama](https://defillama.com/) is the largest TVL aggregator for DeFi (Decentralized Finance). Our data is fully open-source and maintained by a team of passionate individuals and contributors from hundreds of protocols.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/defi-llama](https://www.turboeth.xyz/integration/defi-llama)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/defi-llama](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/defi-llama)
+
+**Folder Structure:**
+```
+integrations/defi-llama/
+├─ components/
+│  ├─ form-chart.tsx
+│  ├─ form-current-price.tsx
+│  ├─ form-historical-price.tsx
+│  ├─ form-percentage-change.tsx
+│  ├─ index.ts
+│  ├─ output-data.tsx
+├─ hooks/
+│  ├─ coins/
+│  │  ├─ index.ts
+│  │  ├─ use-chart.ts
+│  │  ├─ use-current-token-price.ts
+│  │  ├─ use-historical-token-price.ts
+│  │  ├─ use-token-percentage-change.ts
+├─ utils/
+│  ├─ index.ts
+│  ├─ types.ts
+├─ index.ts
+├─ README.md
+```

--- a/integration/api/gelato.mdx
+++ b/integration/api/gelato.mdx
@@ -1,0 +1,77 @@
+---
+title: "🍦 Gelato"
+description: "Automate Smart Contract Execution"
+---
+
+[Gelato Network](https://gelato.network/) is a prominent automation system on the Ethereum blockchain, encompassing a versatile framework for developers and users.
+
+Gelato Network's mission is to automate smart contract executions on Ethereum, simplifying complex on-chain tasks and operations. It aims to provide a seamless infrastructure that triggers automated transactions based on pre-set conditions. Gelato's tools have become pivotal in creating efficient decentralized applications (dApps) and enabling seamless user experiences within the blockchain space.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/gelato](https://www.turboeth.xyz/integration/gelato)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/gelato](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/gelato)
+
+**Folder Structure:**
+```
+integrations/gelato/
+├── abis
+├── components
+│   ├── active-task-preview.tsx
+│   ├── active-tasks.tsx
+│   ├── create-task
+│   │   ├── contract-input.tsx
+│   │   ├── create-task.tsx
+│   │   ├── execution-values.tsx
+│   │   ├── function-input.tsx
+│   │   ├── hooks
+│   │   │   └── use-wizard.ts
+│   │   ├── index.ts
+│   │   ├── interval-input.tsx
+│   │   ├── payment-input.tsx
+│   │   ├── resolver-input.tsx
+│   │   ├── restriction-info.tsx
+│   │   └── task-name-input.tsx
+│   ├── errors
+│   │   └── validation-error.tsx
+│   ├── index.tsx
+│   ├── rename-task.tsx
+│   └── task-view
+│       ├── executing-address.tsx
+│       ├── function-data.tsx
+│       ├── index.ts
+│       ├── input-values.tsx
+│       ├── interval-values.tsx
+│       ├── payment-info.tsx
+│       ├── resolver-values.tsx
+│       └── task-view.tsx
+├── graphql
+│   ├── codegen.ts
+│   ├── graphql
+│   │   └── generated
+│   │       ├── gql.ts
+│   │       ├── graphql.ts
+│   │       └── index.ts
+│   └── tasks.graphql
+├── hooks
+│   ├── index.ts
+│   ├── use-abi.ts
+│   ├── use-active-tasks.ts
+│   ├── use-automate-sdk.ts
+│   ├── use-cancel-task.ts
+│   ├── use-is-automate-supported.ts
+│   ├── use-msg-sender.ts
+│   ├── use-new-task.ts
+│   ├── use-rename-task.ts
+│   ├── use-task-resolver.ts
+│   └── use-task.ts
+├── index.ts
+├── README.md
+├── utils
+│   ├── constants.ts
+│   ├── helpers.ts
+│   ├── resolverDecoder.ts
+│   └── types.ts
+├── index.ts
+└── README.md
+```

--- a/integration/api/gitcoin-passport.mdx
+++ b/integration/api/gitcoin-passport.mdx
@@ -1,0 +1,40 @@
+---
+title: "🌎 Gitcoin Passport"
+description: "Take control of your identity"
+---
+
+By collecting “stamps” of validation for your identity and online reputation, you can gain access to the most trustworthy web3 experiences and maximize your ability to benefit from platforms like Gitcoin Grants. The more you verify your identity, the more opportunities you will have to vote and participate across the web3.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/gitcoin-passport](https://www.turboeth.xyz/integration/gitcoin-passport)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/gitcoin-passport](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/gitcoin-passport)
+
+**Folder Structure:**
+```
+integrations/gitcoin-passport
+├─ api/
+│  ├─ address-score.ts
+│  ├─ address-stamps.ts
+│  ├─ signing-message.ts
+│  ├─ stamps-metadata.ts
+│  ├─ submit-passport.ts
+├─ components/
+│  ├─ list-stamps.tsx
+│  ├─ score-gate.tsx
+│  ├─ stamp-card.tsx
+│  ├─ stamp-gate.tsx
+│  ├─ submit-passport-button.tsx
+├─ hooks/
+│  ├─ use-get-address-stamps.ts
+│  ├─ use-get-score.ts
+│  ├─ use-get-stamps-metadata.ts
+│  ├─ use-submit-passport.ts
+├─ utils/
+│  ├─ config.ts
+│  ├─ data-types.ts
+│  ├─ types.ts
+├─ constants.ts
+├─ types.ts
+├─ README.md
+```

--- a/integration/api/introduction.mdx
+++ b/integration/api/introduction.mdx
@@ -7,3 +7,7 @@ API integrations provide a simple way to interact with external APIs. Currently,
 - [🪩 Disco](/integration/api/disco) - Web3 identity simplified 
 - [📜 Etherscan](/integration/api/etherscan) - Blockchain metadata
 - [🤖 OpenAI](/integration/api/openai) -  Add AI to your app
+- [🍦 Gelato](/integration/api/gelato) -  Automate Smart Contract Execution
+- [⛓️ Moralis](/integration/api/moralis) -  Enterprise-grade APIs and real-time blockchain data
+- [🌎 Gitcoin Passport](/integration/api/gitcoin-passport) - Take control of your identity
+- [🦙 DefiLlama](/integration/api/defi-llama) - Take control of your identity

--- a/integration/api/moralis.mdx
+++ b/integration/api/moralis.mdx
@@ -1,0 +1,48 @@
+---
+title: "⛓️ Moralis"
+description: "Enterprise-grade APIs and real-time blockchain data"
+---
+
+[Moralis](https://moralis.io/) is a leading crypto data provider that helps companies build great user experiences, drive engagement, growth and revenue in their applications.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/moralis](https://www.turboeth.xyz/integration/moralis)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/moralis](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/moralis)
+
+**Folder Structure:**
+```
+integrations/moralis
+├─ api/
+│  ├─ events.ts
+│  ├─ transaction.ts
+├─ client/
+│  ├─ index.ts
+├─ components/
+│  ├─ events/
+│  │  ├─ form-get-contract-events.tsx
+│  │  ├─ form-get-contract-logs.tsx
+│  ├─ transaction/
+│  │  ├─ form-get-internal-transactions.tsx
+│  │  ├─ form-get-transaction-verbose.tsx
+│  │  ├─ form-get-transaction.tsx
+│  │  ├─ form-get-wallet-transactions-verbose.tsx
+│  │  ├─ form-get-wallet-transactions.tsx
+│  ├─ output-data.tsx
+├─ hooks/
+│  ├─ events/
+│  │  ├─ index.ts
+│  │  ├─ use-get-contract-events.ts
+│  │  ├─ use-get-contract-logs.ts
+│  ├─ transaction/
+│  │  ├─ index.ts
+│  │  ├─ use-get-internal-transactions.ts
+│  │  ├─ use-get-transaction-verbose.ts
+│  │  ├─ use-get-transaction.ts
+│  │  ├─ use-get-wallet-transactions-verbose.ts
+│  │  ├─ use-get-wallet-transactions.ts
+├─ utils/
+│  ├─ types.ts
+├─ index.ts
+├─ README.md
+```

--- a/integration/how-it-works.mdx
+++ b/integration/how-it-works.mdx
@@ -59,8 +59,20 @@ Smart contract integrations are specifically designed to streamline the interact
   <Card title="🖼️ ERC721" href="/integration/smart-contract/erc721">
     Interact with ERC721 contracts
   </Card>
-    <Card title="💰 PoolTogether" href="/integration/smart-contract/pool-together">
+  <Card title="🖼️ ERC1155" href="/integration/smart-contract/erc1155">
+    Interact with ERC1155 contracts
+  </Card>
+  <Card title="💰 PoolTogether" href="/integration/smart-contract/pooltogether">
    PoolTogether is a prize savings protocol
+  </Card>
+  <Card title="👻 Aave" href="/integration/smart-contract/aave">
+   Borrow and lend assets seamlessly
+  </Card>
+  <Card title="💾 Arweave" href="/integration/smart-contract/arweave">
+   Permanent information storage
+  </Card>
+  <Card title="🌿 Lens Protocol" href="/integration/smart-contract/lens-protocol">
+   Social Layer for Web3
   </Card>
 </CardGroup>
 
@@ -78,6 +90,18 @@ API integrations are designed to simplify the interaction with external APIs.
   <Card title="🤖 OpenAI" href="/integration/api/openai">
     Add AI to your app
   </Card>
+  <Card title="🍦 Gelato" href="/integration/api/gelato">
+    Automate Smart Contract Execution
+  </Card>
+  <Card title="⛓️ Moralis" href="/integration/api/moralis">
+    Enterprise-grade APIs and real-time blockchain data
+  </Card>
+  <Card title="🌎 Gitcoin Passport" href="/integration/api/gitcoin-passport">
+    Take control of your identity
+  </Card>
+  <Card title="🦙 DefiLlama" href="/integration/api/defi-llama">
+    Open and transparent DeFi analytics
+  </Card>
 </CardGroup>
 
 ### [💻 SDK Integrations](/integration/sdk/introduction)
@@ -92,6 +116,9 @@ SDK integrations are designed to simplify interactions with protocols and applic
   </Card>
   <Card title="📺 Livepeer" href="/integration/sdk/livepeer">
     Video infrastructure protocol
+  </Card>
+  <Card title="🔔 Push Protocol" href="/integration/sdk/push-protocol">
+    Web3 communication network
   </Card>
 </CardGroup>
 

--- a/integration/sdk/introduction.mdx
+++ b/integration/sdk/introduction.mdx
@@ -7,3 +7,4 @@ SDK integrations provide simple hooks and components on top of the SDKs provided
 - [🔥 Lit Protocol](/integration/sdk/lit-protocol)
 - [🌉 Connext](/integration/sdk/connext)
 - [📺 Livepeer](/integration/sdk/livepeer)
+- [🔔 Push Protocol](/integration/sdk/push-protocol)

--- a/integration/sdk/push-protocol.mdx
+++ b/integration/sdk/push-protocol.mdx
@@ -1,0 +1,46 @@
+---
+title: "🔔 Push Protocol"
+description: "Video infrastructure protocol"
+---
+
+
+[Push Protocol](https://push.org/) is a cutting-edge decentralized communication layer optimized for Web3 applications and platforms.
+
+Push Protocol's primary objective is to enable real-time, decentralized notifications and updates for dApps, users, and Web3 services. Bridging the gap between traditional notification systems and the decentralized world, Push Protocol offers a robust infrastructure that enhances user experience by providing timely alerts and updates without compromising on decentralization and security. As the Web3 ecosystem continues to grow, Push Protocol stands as a pivotal solution for seamless and efficient communication in decentralized applications. 
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/push-protocol](https://www.turboeth.xyz/integration/push-protocol)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/push-protocol](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/push-protocol)
+
+**Folder Structure:**
+```
+integrations/push
+├── components
+│   ├── channel-card.tsx
+│   ├── channel-search.tsx
+│   ├── chat.tsx
+│   ├── index.ts
+│   ├── loadable.tsx
+│   ├── notification-bell.tsx
+│   ├── notification-feed.tsx
+│   ├── notification-item.tsx
+│   └── subscribe-button.tsx
+├── hooks
+│   ├── index.ts
+│   ├── use-channel.ts
+│   ├── use-chats.ts
+│   ├── use-create-user.ts
+│   ├── use-notifications.ts
+│   ├── use-search-channels.ts
+│   ├── use-send-notifications.ts
+│   ├── use-subscribe-channel.ts
+│   ├── use-unsubscribe-channel.ts
+│   └── use-user-subscriptions.ts
+└── utils
+    ├── constants.ts
+    ├── helpers.ts
+    └── types.ts
+├── index.ts
+└── README.md
+```

--- a/integration/smart-contract/aave.mdx
+++ b/integration/smart-contract/aave.mdx
@@ -1,0 +1,43 @@
+---
+title: "👻 Aave"
+description: "Borrow and lend assets seamlessly"
+---
+
+[Aave](https://aave.com/) is a pioneering decentralized finance (DeFi) protocol that provides lending and borrowing services on the Ethereum blockchain.
+
+Established in 2017 originally as ETHLend, Aave has evolved into one of the largest and most influential DeFi platforms in the crypto space. It allows users to lend, borrow, and earn interest on crypto assets in a permissionless and transparent manner. By utilizing innovative features like flash loans and rate-switching, Aave has significantly expanded the possibilities within the DeFi sector. With its emphasis on security, user-centricity, and continual innovation, Aave remains at the forefront of reshaping financial services in a decentralized paradigm.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/aave](https://www.turboeth.xyz/integration/aave)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/aave](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/aave)
+
+**Folder Structure:**
+```
+integrations/aave
+├── abis
+│ ├── pool-abi.ts
+│ └── ui-pool-data-provider-abi.ts
+├── components
+│ ├── asset-to-borrow-item.tsx
+│ ├── asset-to-supply-item.tsx
+│ ├── borrowed-assets-item.tsx
+│ ├── general-info.tsx
+│ ├── health-factor.tsx
+│ ├── list-assets-to-borrow.tsx
+│ ├── list-assets-to-supply.tsx
+│ ├── list-borrowed-assets.tsx
+│ ├── list-supplied-assets.tsx
+│ ├── spinner.tsx
+│ └── supplied-assets-item.tsx
+├── generated
+│ └── aave-wagmi.ts
+├── hooks
+│ └── use-aave.ts
+├── utils
+│ ├── index.ts
+│ ├── market-config.ts
+│ └── types.ts
+│── wagmi.config.ts
+└── README.md
+```

--- a/integration/smart-contract/arweave.mdx
+++ b/integration/smart-contract/arweave.mdx
@@ -1,0 +1,33 @@
+---
+title: "💾 Arweave"
+description: "Permanent information storage"
+---
+
+[Arweave](https://arweave.org/) is an innovative decentralized storage network designed to offer permanent, low-cost data storage on the blockchain.
+
+Launched in 2018, Arweave's unique approach to storage revolves around its "pay once, store forever" model, allowing data to be archived on its network indefinitely without recurring fees. It uses a novel proof-of-access consensus mechanism that ensures data is stored perpetually, making it an attractive solution for preserving historical records, digital art, academic research, and other forms of important information. As the digital world grapples with issues of data permanence and censorship, Arweave stands out as a revolutionary platform committed to ensuring that valuable information remains accessible for future generations.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/arweave](https://www.turboeth.xyz/integration/arweave)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/arweave](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/arweave)
+
+**Folder Structure:**
+```
+integrations/arweave/
+├─ abis/
+│  ├─ *.ts
+├─ client/
+│  ├─ *.ts
+├─ components/
+│  ├─ *.tsx
+├─ generated/
+│  ├─ *.ts
+├─ hooks/
+│  ├─ *.ts
+├─ utils/
+│  ├─ *.ts
+├─ index.ts
+├─ README.md
+├─ wagmi.config.ts
+```

--- a/integration/smart-contract/erc1155.mdx
+++ b/integration/smart-contract/erc1155.mdx
@@ -1,0 +1,52 @@
+---
+title: "🖼️ ERC1155"
+description: "ERC1155 read, write and event hooks + components"
+---
+
+[ERC1155](https://ethereum.org/en/developers/docs/standards/tokens/erc-1155/) is a comprehensive multi-token standard within the Ethereum ecosystem.
+
+It provides a standardized interface for contracts that can simultaneously handle multiple token types. With ERC1155, a single contract can encompass a vast range of tokens, be they purely fungible, non-fungible, or even semi-fungible in nature. This adaptability makes it a powerful tool for developers, allowing for intricate token economies and interactions under a unified contract framework.
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/erc1155](https://www.turboeth.xyz/integration/erc1155)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/erc1155](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/erc1155)
+
+**Folder Structure:**
+```
+integrations/erc1155
+├─ artifacts/
+|  ├─ core/
+│  |  ├─ erc1155-abi.ts
+│  |  ├─ erc1155-bytecode.ts
+|  ├─ test/
+│  |  ├─ erc1155-abi.ts
+│  |  ├─ erc1155-bytecode.ts
+├─ components/
+│  ├─ erc1155-deploy.tsx
+│  ├─ erc1155-name.tsx
+│  ├─ erc1155-owner-of.tsx
+│  ├─ erc1155-read.tsx
+│  ├─ erc1155-set-token-storage.tsx
+│  ├─ erc1155-symbol.tsx
+│  ├─ erc1155-token-uri-description.tsx
+│  ├─ erc1155-token-uri-image.tsx
+│  ├─ erc1155-token-uri-name.tsx
+│  ├─ erc1155-token-uri.tsx
+│  ├─ erc1155-contract-uri.tsx
+│  ├─ erc1155-total-supply.tsx
+│  ├─ erc1155-write-approve.tsx
+│  ├─ erc1155-write-mint.tsx
+│  ├─ erc1155-write-transfer.tsx
+│  ├─ erc1155-write-batch-transfer.tsx
+├─ generated/
+│  ├─ erc1155-wagmi.ts
+├─ hooks/
+│  ├─ use-erc1155-metadata.ts
+│  ├─ use-erc1155-token-storage.ts
+├─ utils/
+│  ├─ types.ts
+├─ index.ts
+├─ wagmi.config.ts
+├─ README.md
+```

--- a/integration/smart-contract/introduction.mdx
+++ b/integration/smart-contract/introduction.mdx
@@ -6,4 +6,8 @@ description: "Smart contract integrations are specifically designed to streamlin
 Smart contract integrations can be added or removed depending on the contracts you are working with. Currently, the following integrations are available:
 - [🪙 ERC20](/integration/smart-contract/erc20)
 - [🖼️ ERC721](/integration/smart-contract/erc721)
-- [💰 PoolTogether](/integration/smart-contract/pool-together)
+- [🖼️ ERC1155](/integration/smart-contract/erc1155)
+- [💰 PoolTogether](/integration/smart-contract/pooltogether)
+- [👻 Aave](/integration/smart-contract/aave)
+- [💾 Arweave](/integration/smart-contract/arweave)
+- [🌿 Lens Protoco](/integration/smart-contract/aave)

--- a/integration/smart-contract/lens-protocol.mdx
+++ b/integration/smart-contract/lens-protocol.mdx
@@ -1,0 +1,61 @@
+---
+title: "🌿 Lens Protocol"
+description: "Social Layer for Web3y"
+---
+
+The [Lens Protocol](https://www.lens.xyz/) is a Web3 social graph on the Polygon Proof-of-Stake blockchain. It is designed to empower creators to own the links between themselves and their community, forming a fully composable, user-owned social graph. The protocol is built from the ground up with modularity in mind, allowing new features and fixes to be added while ensuring immutable user-owned content and social relationships.
+
+
+# Integration
+
+- Demo: [turboeth.xyz/integration/lens-protocol](https://www.turboeth.xyz/integration/lens-protocol)
+- Code: [github.com/turbo-eth/template-web3-app/tree/integrations/integrations/lens-protocol](https://github.com/turbo-eth/template-web3-app/tree/integrations/integrations/lens-protocol)
+
+**Folder Structure:**
+```
+integrations/lens-protocol
+├── components
+│   ├── auth
+│   │   ├── is-user-authenticated.tsx
+│   │   ├── login-button.tsx
+│   │   ├── logout-button.tsx
+│   │   └── not-authenticated-yet.tsx
+│   ├── feed.tsx
+│   ├── load-more-button.tsx
+│   ├── navbar.tsx
+│   ├── profile
+│   │   ├── address-profiles.tsx
+│   │   ├── explore-profiles.tsx
+│   │   ├── follow-unfollow-button.tsx
+│   │   ├── owned-profiles.tsx
+│   │   ├── profile-card.tsx
+│   │   ├── profile-list-modal.tsx
+│   │   ├── profile-publications.tsx
+│   │   ├── profile-revenue.tsx
+│   │   ├── profile-stats.tsx
+│   │   ├── profile.tsx
+│   │   └── search-profiles.tsx
+│   └── publications
+│       ├── actions
+│       │   ├── button.tsx
+│       │   ├── comment.tsx
+│       │   ├── index.tsx
+│       │   ├── like.tsx
+│       │   └── mirror.tsx
+│       ├── commnets.tsx
+│       ├── explore-publications.tsx
+│       ├── publication-actions-and-stats.tsx
+│       ├── publication-card.tsx
+│       ├── publication-revenue.tsx
+│       ├── publication.tsx
+│       ├── search-publications.tsx
+│       └── stats
+│           ├── index.tsx
+│           └── stat.tsx
+├── hooks
+│   └── use-create-profile.ts
+├── lens-provider.ts
+├── utils
+│   └── index.ts
+├── README.md
+```

--- a/mint.json
+++ b/mint.json
@@ -59,7 +59,11 @@
         "integration/smart-contract/introduction",
         "integration/smart-contract/erc20",
         "integration/smart-contract/erc721",
-        "integration/smart-contract/pooltogether"
+        "integration/smart-contract/erc1155",
+        "integration/smart-contract/pooltogether",
+        "integration/smart-contract/aave",
+        "integration/smart-contract/arweave",
+        "integration/smart-contract/lens-protocol"
       ]
     },
     {
@@ -68,7 +72,13 @@
         "integration/api/introduction", 
         "integration/api/disco", 
         "integration/api/etherscan", 
-        "integration/api/openai" ]
+        "integration/api/openai",
+        "integration/api/gelato",
+        "integration/api/moralis",
+        "integration/api/gitcoin-passport",
+        "integration/api/defi-llama"
+        
+      ]
     },
     {
       "group": "💻 SDK Integrations",
@@ -76,7 +86,8 @@
         "integration/sdk/introduction",
         "integration/sdk/lit-protocol",
         "integration/sdk/connext",
-        "integration/sdk/livepeer"
+        "integration/sdk/livepeer",
+        "integration/sdk/push-protocol"
       ]
     },
     {

--- a/overview.mdx
+++ b/overview.mdx
@@ -43,8 +43,20 @@ Smart contract integrations are specifically designed to streamline the interact
   <Card title="🖼️ ERC721" href="/integration/smart-contract/erc721">
     Interact with ERC721 contracts
   </Card>
-    <Card title="💰 PoolTogether" href="/integration/smart-contract/pooltogether">
+  <Card title="🖼️ ERC1155" href="/integration/smart-contract/erc1155">
+    Interact with ERC1155 contracts
+  </Card>
+  <Card title="💰 PoolTogether" href="/integration/smart-contract/pooltogether">
    PoolTogether is a prize savings protocol
+  </Card>
+  <Card title="👻 Aave" href="/integration/smart-contract/aave">
+   Borrow and lend assets seamlessly
+  </Card>
+  <Card title="💾 Arweave" href="/integration/smart-contract/arweave">
+   Permanent information storage
+  </Card>
+  <Card title="🌿 Lens Protocol" href="/integration/smart-contract/lens-protocol">
+   Social Layer for Web3
   </Card>
 </CardGroup>
 
@@ -61,6 +73,18 @@ API integrations are designed to simplify the interaction with external APIs.
   <Card title="🤖 OpenAI" href="/integration/api/openai">
     Add AI to your app
   </Card>
+  <Card title="🍦 Gelato" href="/integration/api/gelato">
+    Automate Smart Contract Execution
+  </Card>
+  <Card title="⛓️ Moralis" href="/integration/api/moralis">
+    Enterprise-grade APIs and real-time blockchain data
+  </Card>
+  <Card title="🌎 Gitcoin Passport" href="/integration/api/gitcoin-passport">
+    Take control of your identity
+  </Card>
+  <Card title="🦙 DefiLlama" href="/integration/api/defi-llama">
+    Open and transparent DeFi analytics
+  </Card>
 </CardGroup>
 
 ### [💻 SDK Integrations](/integration/sdk/introduction)
@@ -75,6 +99,9 @@ SDK integrations are designed to simplify interactions with protocols and applic
   </Card>
   <Card title="📺 Livepeer" href="/integration/sdk/livepeer">
     Video infrastructure protocol
+  </Card>
+  <Card title="🔔 Push Protocol" href="/integration/sdk/push-protocol">
+    Web3 communication network
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
This PR adds the missing TurboETH integration to the docs:
- ERC1155
- Gelato
- Push Protocol
- Aave
- Arweave
- Lens
- Moralis
- Gitcoin Passport
- DefiLlama